### PR TITLE
Fix Search Results

### DIFF
--- a/methods/search_indexes.py
+++ b/methods/search_indexes.py
@@ -1,5 +1,5 @@
 from haystack import indexes
-from .models import Method, MethodSet
+from .models import Method
 
 
 class MethodIndex(indexes.SearchIndex, indexes.Indexable):
@@ -11,16 +11,4 @@ class MethodIndex(indexes.SearchIndex, indexes.Indexable):
 
     def index_queryset(self, using=None):
         """Used when the entire index for model is updated."""
-        return self.get_model().objects.all()
-
-
-class MethodSetIndex(indexes.SearchIndex, indexes.Indexable):
-    text = indexes.CharField(document=True, use_template=True)
-    p_stage = indexes.CharField(model_attr='p_stage')
-    notes = indexes.CharField(model_attr='notes')
-
-    def get_model(self):
-        return MethodSet
-
-    def index_queryset(self, using=None):
         return self.get_model().objects.all()

--- a/methods/tests/test_views.py
+++ b/methods/tests/test_views.py
@@ -1,0 +1,15 @@
+from django.test import TestCase, Client
+
+
+class TestSearchView(TestCase):
+
+    fixtures = ['methods.json', 'methodset.json', 'firsttowerbellpeal.json']
+
+    @classmethod
+    def setUpClass(cls):
+        super(TestSearchView, cls).setUpClass()
+        cls.client = Client()
+
+    def test_search_for_plain_bob(self):
+        response = self.client.get('/search/?q=plain+bob')
+        self.assertContains(response, 'Plain Bob Minimus (4 bells)')

--- a/templates/search/indexes/methods/methodset_text.txt
+++ b/templates/search/indexes/methods/methodset_text.txt
@@ -1,2 +1,0 @@
-{{ object.p_stage }}
-{{ object.notes }}


### PR DESCRIPTION
`MethodSet` was being included in the search results which confused the template. I think this wasn't noticed before because the `MethodSet` results occurred lower in the rankings than the `Method` results - but this doesn't seem to be the case any more. 